### PR TITLE
Ensure sentry startup

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -21,7 +21,7 @@ import ReactGA from "react-ga4";
 import "~/styles/global.css";
 import layoutStyles from "~/styles/layout.css?url";
 import errorStyles from "~/styles/error.css?url";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export const meta: MetaFunction = () => [
   {
@@ -50,32 +50,34 @@ export const loader: LoaderFunction = async () => {
 };
 
 const InitializeSentry = (environment: string) => {
-  Sentry.init({
-    dsn: "https://c8a47fcd86fce0c2b5913396f6b08533@o4508546853830656.ingest.us.sentry.io/4508546855272448",
-    tracesSampleRate: 1,
-    environment,
+  if (!Sentry.isInitialized()) {
+    Sentry.init({
+      dsn: "https://c8a47fcd86fce0c2b5913396f6b08533@o4508546853830656.ingest.us.sentry.io/4508546855272448",
+      tracesSampleRate: 1,
+      environment,
 
-    integrations: [
-      Sentry.browserTracingIntegration({
-        useEffect,
-        useLocation,
-        useMatches,
-      }),
-      Sentry.replayIntegration({
-        maskAllText: true,
-        blockAllMedia: true,
-      }),
-    ],
+      integrations: [
+        Sentry.browserTracingIntegration({
+          useEffect,
+          useLocation,
+          useMatches,
+        }),
+        Sentry.replayIntegration({
+          maskAllText: true,
+          blockAllMedia: true,
+        }),
+      ],
 
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1,
-    beforeSend(event) {
-      if (window.location.hostname === "localhost") {
-        return null;
-      }
-      return event;
-    },
-  });
+      replaysSessionSampleRate: 0.1,
+      replaysOnErrorSampleRate: 1,
+      beforeSend(event) {
+        if (window.location.hostname === "localhost") {
+          return null;
+        }
+        return event;
+      },
+    });
+  }
 };
 
 function App() {
@@ -86,7 +88,7 @@ function App() {
 
   useEffect(() => {
     if (!SENTRY_ENVIRONMENT) {
-      console.error("No sentry environment. Bugs will not be reported.");
+      console.warn("No sentry environment. Bugs will not be reported.");
       return;
     }
 

--- a/app/routes/project.$projectId/components/ui/Footer.tsx
+++ b/app/routes/project.$projectId/components/ui/Footer.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import "~/styles/footer.css";
+import copyright from "~/styles/images/copyright.svg";
 
 export const Footer: React.FC = () => {
   return (
     <footer>
-      <div className="fake-copyright">© Parrit 2025</div>
+      <div className="fake-copyright flex items-center space-x-1">
+        <img className="h-2 w-2 inline-block" src={copyright} />
+        <span>Parrit 2025</span>
+      </div>
       <div className="footer-links">
         <a
           target="_blank"

--- a/app/styles/images/copyright.svg
+++ b/app/styles/images/copyright.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="88.189156mm"
+   height="88.189156mm"
+   viewBox="0 0 88.189156 88.189156"
+   version="1.1"
+   id="svg5"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-3.5021417,-3.1656189)">
+    <g
+       id="g711"
+       transform="translate(-80.838705,-78.952785)">
+      <circle
+         style="fill:none;stroke:#000000;stroke-width:4.16401;stroke-opacity:0.967595"
+         id="path234"
+         cx="128.43542"
+         cy="126.21298"
+         r="42.012573" />
+      <text
+         xml:space="preserve"
+         style="font-size:78.2494px;font-family:Cousine;-inkscape-font-specification:'Cousine, Normal';fill:#000000;stroke:none;stroke-width:3.05721;stroke-opacity:0.967595"
+         x="99.68412"
+         y="153.14941"
+         id="text446"><tspan
+           sodipodi:role="line"
+           id="tspan444"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:78.2494px;font-family:Arimo;-inkscape-font-specification:'Arimo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;stroke:none;stroke-width:3.0572"
+           x="99.68412"
+           y="153.14941">C</tspan></text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
- use an SVG for copyright

Apparently the copyright symbol has different encodings on different servers and causes a crash when the server encoding is different from the browser encoding.